### PR TITLE
fix bug with gmapping

### DIFF
--- a/launch/state_machines/demo_intern.launch
+++ b/launch/state_machines/demo_intern.launch
@@ -13,7 +13,7 @@
         <!-- LOCALIZATION GMAPPING -->
         <include file="$(find robot_launch_files)/launch/localization/gmapping.launch">
             <arg name="machine" value="hero2"/>
-            <arg name="sensor" value="base_scan"/>
+            <arg name="sensor" value="base_laser"/>
         </include>
 
         <!-- NAVIGATION GMAPPING -->


### PR DESCRIPTION
gmapping did not work because the sensor has been renamed from 'base_scan' to 'base_laser'. This caused gmapping ot listen to the wrong topic. This was solved by passing the correct sensor name argument.