### PR TITLE
hero start systemd service working

### DIFF
--- a/scripts/services/hero1-demo/hero1-demo-start.service
+++ b/scripts/services/hero1-demo/hero1-demo-start.service
@@ -1,15 +1,16 @@
 [Unit]
 Description=HERO start.launch
-After=hero1-roscore.service
-Requires=hero1-roscore.service
+After=hero1-demo-roscore.service
+Requires=hero1-demo-roscore.service
 
 [Install]
 WantedBy=multi-user.target
 
 [Service]
 EnvironmentFile=-/etc/opt/tmc/robot/version
-User=administrator
-LimitMEMLOCK=10240000000
+Environment=ROS_HOME=/home/demo/.ros
+User=demo
+LimitMEMLOCK=infinity
 LimitRTPRIO=51
 Restart=on-failure
 ExecStart=/bin/bash -c 'source /home/administrator/.tue/setup.bash && roslaunch hero_bringup start.launch --wait'

--- a/scripts/services/hero1/hero1-start.service
+++ b/scripts/services/hero1/hero1-start.service
@@ -1,0 +1,16 @@
+[Unit]
+Description=HERO start.launch
+After=hero1-roscore.service
+Requires=hero1-roscore.service
+
+[Install]
+WantedBy=multi-user.target
+
+[Service]
+EnvironmentFile=-/etc/opt/tmc/robot/version
+Environment=ROS_HOME=/home/administrator/.ros
+User=administrator
+LimitMEMLOCK=infinity
+LimitRTPRIO=51
+Restart=on-failure
+ExecStart=/bin/bash -c 'source /home/administrator/.tue/setup.bash && roslaunch hero_bringup start.launch --wait'


### PR DESCRIPTION
RRPRIO limit is taken from tmc docker settings
MEM limit is set to infinity, higher than tmc docker settings, as there is more running
than the tmc docker