### PR TITLE
lower costmap object height

### DIFF
--- a/parameters/world_modeling/world_model_plugin_navigation.yaml
+++ b/parameters/world_modeling/world_model_plugin_navigation.yaml
@@ -8,4 +8,4 @@ parameters:
         resolution: 0.05
         frame_id: map
         min_z: 0.025
-        max_z: 1.8
+        max_z: 1.65


### PR DESCRIPTION
HERO is max ~160 tall, so no need to include everything up to 1.8.
This excludes the TV in impuls.