### PR TITLE
(launch) add diagnostics remap needed for ED

### DIFF
--- a/launch/state_machines/challenge_cleanup.launch
+++ b/launch/state_machines/challenge_cleanup.launch
@@ -1,7 +1,8 @@
 <?xml version="1.0"?>
-
 <launch>
     <arg name="robot_name" value="hero" />
+
+    <remap from="/diagnostics" to="/$(arg robot_name)/diagnostics" />
 
     <group ns="$(arg robot_name)">
 

--- a/launch/state_machines/challenge_final.launch
+++ b/launch/state_machines/challenge_final.launch
@@ -1,7 +1,8 @@
 <?xml version="1.0"?>
-
 <launch>
     <arg name="robot_name" value="hero" />
+
+    <remap from="/diagnostics" to="/$(arg robot_name)/diagnostics" />
 
     <group ns="$(arg robot_name)">
 

--- a/launch/state_machines/challenge_find_my_mates.launch
+++ b/launch/state_machines/challenge_find_my_mates.launch
@@ -1,7 +1,8 @@
 <?xml version="1.0"?>
-
 <launch>
     <arg name="robot_name" value="hero" />
+
+    <remap from="/diagnostics" to="/$(arg robot_name)/diagnostics" />
 
     <group ns="$(arg robot_name)">
 

--- a/launch/state_machines/challenge_gpsr.launch
+++ b/launch/state_machines/challenge_gpsr.launch
@@ -1,12 +1,12 @@
 <?xml version="1.0"?>
-
 <launch>
-
     <arg name="robot_name" value="hero" />
     <arg name="skip" default="false" />
     <arg name="number_of_tasks" default="3" />
     <arg name="test_mode" default="false" />
     <arg name="time_limit" default="5" />
+
+    <remap from="/diagnostics" to="/$(arg robot_name)/diagnostics" />
 
     <group ns="$(arg robot_name)">
 

--- a/launch/state_machines/challenge_hand_me_that.launch
+++ b/launch/state_machines/challenge_hand_me_that.launch
@@ -1,7 +1,8 @@
 <?xml version="1.0"?>
-
 <launch>
     <arg name="robot_name" value="hero" />
+
+    <remap from="/diagnostics" to="/$(arg robot_name)/diagnostics" />
 
     <group ns="$(arg robot_name)">
 

--- a/launch/state_machines/challenge_receptionist.launch
+++ b/launch/state_machines/challenge_receptionist.launch
@@ -1,7 +1,8 @@
 <?xml version="1.0"?>
-
 <launch>
     <arg name="robot_name" value="hero" />
+
+    <remap from="/diagnostics" to="/$(arg robot_name)/diagnostics" />
 
     <group ns="$(arg robot_name)">
 

--- a/launch/state_machines/challenge_restaurant.launch
+++ b/launch/state_machines/challenge_restaurant.launch
@@ -1,8 +1,8 @@
 <?xml version="1.0"?>
-
 <launch>
-
     <arg name="robot_name" value="hero" />
+
+    <remap from="/diagnostics" to="/$(arg robot_name)/diagnostics" />
 
     <group ns="$(arg robot_name)">
 

--- a/launch/state_machines/challenge_rips.launch
+++ b/launch/state_machines/challenge_rips.launch
@@ -1,7 +1,8 @@
 <?xml version="1.0"?>
-
 <launch>
     <arg name="robot_name" value="hero" />
+
+    <remap from="/diagnostics" to="/$(arg robot_name)/diagnostics" />
 
     <group ns="$(arg robot_name)">
 

--- a/launch/state_machines/challenge_serving_drinks.launch
+++ b/launch/state_machines/challenge_serving_drinks.launch
@@ -1,7 +1,8 @@
 <?xml version="1.0"?>
-
 <launch>
     <arg name="robot_name" value="hero" />
+
+    <remap from="/diagnostics" to="/$(arg robot_name)/diagnostics" />
 
     <group ns="$(arg robot_name)">
 

--- a/launch/state_machines/challenge_set_the_table.launch
+++ b/launch/state_machines/challenge_set_the_table.launch
@@ -1,9 +1,11 @@
 <?xml version="1.0"?>
-
 <launch>
     <arg name="robot_name" value="hero" />
 
+    <remap from="/diagnostics" to="/$(arg robot_name)/diagnostics" />
+
     <group ns="$(arg robot_name)">
+
         <!-- NAVIGATION -->
         <include file="$(find robot_launch_files)/launch/navigation/navigation.launch"/>
 

--- a/launch/state_machines/challenge_storing_groceries.launch
+++ b/launch/state_machines/challenge_storing_groceries.launch
@@ -1,7 +1,8 @@
 <?xml version="1.0"?>
-
 <launch>
     <arg name="robot_name" value="hero" />
+
+    <remap from="/diagnostics" to="/$(arg robot_name)/diagnostics" />
 
     <group ns="$(arg robot_name)">
 

--- a/launch/state_machines/challenge_take_out_the_garbage.launch
+++ b/launch/state_machines/challenge_take_out_the_garbage.launch
@@ -1,7 +1,8 @@
 <?xml version="1.0"?>
-
 <launch>
     <arg name="robot_name" value="hero" />
+
+    <remap from="/diagnostics" to="/$(arg robot_name)/diagnostics" />
 
     <group ns="$(arg robot_name)">
 

--- a/launch/state_machines/challenge_where_is_this.launch
+++ b/launch/state_machines/challenge_where_is_this.launch
@@ -1,7 +1,8 @@
 <?xml version="1.0"?>
-
 <launch>
     <arg name="robot_name" value="hero" />
+
+    <remap from="/diagnostics" to="/$(arg robot_name)/diagnostics" />
 
     <group ns="$(arg robot_name)">
 

--- a/launch/state_machines/demo_extern.launch
+++ b/launch/state_machines/demo_extern.launch
@@ -8,6 +8,8 @@
     <arg name="number_of_tasks" default="0" />
     <arg name="time_limit" default="999" />
 
+    <remap from="/diagnostics" to="/$(arg robot_name)/diagnostics" />
+
     <group ns="$(arg robot_name)">
 
         <!-- LOCALIZATION GMAPPING -->

--- a/launch/state_machines/demo_intern.launch
+++ b/launch/state_machines/demo_intern.launch
@@ -8,6 +8,8 @@
     <arg name="number_of_tasks" default="0" />
     <arg name="time_limit" default="999" />
 
+    <remap from="/diagnostics" to="/$(arg robot_name)/diagnostics" />
+
     <group ns="$(arg robot_name)">
 
         <!-- NAVIGATION -->

--- a/launch/state_machines/demo_siza.launch
+++ b/launch/state_machines/demo_siza.launch
@@ -8,6 +8,8 @@
     <arg name="number_of_tasks" default="15" />
     <arg name="time_limit" default="999" />
 
+    <remap from="/diagnostics" to="/$(arg robot_name)/diagnostics" />
+
     <group ns="$(arg robot_name)">
 
         <!-- NAVIGATION GMAPPING -->

--- a/launch/state_machines/free_mode.launch
+++ b/launch/state_machines/free_mode.launch
@@ -3,7 +3,9 @@
 <!-- Checkout README.md to see when to use this launch file -->
 
 <launch>
-    <arg name="robot_name" value="hero"/>
+    <arg name="robot_name" value="hero" />
+
+    <remap from="/diagnostics" to="/$(arg robot_name)/diagnostics" />
 
     <group ns="$(arg robot_name)">
 

--- a/launch/state_machines/free_mode_amcl.launch
+++ b/launch/state_machines/free_mode_amcl.launch
@@ -3,6 +3,8 @@
     <arg name="robot_name" default="hero"/>
     <arg name="map"/>
 
+    <remap from="/diagnostics" to="/$(arg robot_name)/diagnostics" />
+
     <group ns="$(arg robot_name)">
 
         <!-- NAVIGATION -->

--- a/launch/state_machines/gmapping.launch
+++ b/launch/state_machines/gmapping.launch
@@ -1,8 +1,11 @@
 <?xml version="1.0"?>
-
 <launch>
 
-    <group ns="hero">
+    <arg name="robot_name" value="hero" />
+
+    <remap from="/diagnostics" to="/$(arg robot_name)/diagnostics" />
+
+    <group ns="$(arg robot_name)">
 
         <!-- LOCALIZATION GMAPPING -->
         <include file="$(find robot_launch_files)/launch/localization/gmapping.launch">

--- a/launch/state_machines/learn_objects.launch
+++ b/launch/state_machines/learn_objects.launch
@@ -1,7 +1,8 @@
 <?xml version="1.0"?>
-
 <launch>
     <arg name="robot_name" value="hero" />
+
+    <remap from="/diagnostics" to="/$(arg robot_name)/diagnostics" />
 
     <group ns="$(arg robot_name)">
 


### PR DESCRIPTION
This remap is needed as on HERO we publish everything on `/hero/diagnostics` instead of `/diagnostics`.

Getting everything to `/diagnostics` is more difficult.

Tested on HERO. Works like a charm.

Merge before/together with https://github.com/tue-robotics/ed/pull/139