### PR TITLE
add video recorder for challenges

### DIFF
--- a/launch/state_machines/challenge_carry_my_luggage.launch
+++ b/launch/state_machines/challenge_carry_my_luggage.launch
@@ -26,6 +26,12 @@
 
     </group>
 
+    <!-- RECORD VIDEO -->
+    <include file="$(find robot_launch_files)/launch/tools/video_recorder.launch">
+        <arg name="image_topic" value="/hero/head_rgbd_sensor/rgb/image_raw"/>
+        <arg name="filename" value="challenge_carry_my_luggage"/>
+    </include>
+
     <node pkg="challenge_carry_my_luggage" type="node_killer.bash" name="node_killer"
         output="screen" />
 

--- a/launch/state_machines/challenge_clean_the_table.launch
+++ b/launch/state_machines/challenge_clean_the_table.launch
@@ -23,6 +23,12 @@
         </include>
     </group>
 
+    <!-- RECORD VIDEO -->
+    <include file="$(find robot_launch_files)/launch/tools/video_recorder.launch">
+        <arg name="image_topic" value="/hero/head_rgbd_sensor/rgb/image_raw"/>
+        <arg name="filename" value="challenge_clean_the_table"/>
+    </include>
+
     <!-- Start the challenge -->
     <node pkg="challenge_clean_the_table" type="challenge_clean_the_table" name="state_machine" args="hero" output="screen" required="true" />
 

--- a/launch/state_machines/challenge_gpsr.launch
+++ b/launch/state_machines/challenge_gpsr.launch
@@ -33,6 +33,12 @@
 
     </group>
 
+    <!-- RECORD VIDEO -->
+    <include file="$(find robot_launch_files)/launch/tools/video_recorder.launch">
+        <arg name="image_topic" value="/hero/head_rgbd_sensor/rgb/image_raw"/>
+        <arg name="filename" value="challenge_gpsr"/>
+    </include>
+
     <!-- Start the challenge -->
     <node pkg="challenge_gpsr" type="gpsr.py" name="state_machine" output="screen" required="true">
         <param name="robot_name" value="$(arg robot_name)" />

--- a/launch/state_machines/challenge_receptionist.launch
+++ b/launch/state_machines/challenge_receptionist.launch
@@ -21,6 +21,12 @@
         </include>
     </group>
 
+    <!-- RECORD VIDEO -->
+    <include file="$(find robot_launch_files)/launch/tools/video_recorder.launch">
+        <arg name="image_topic" value="/hero/head_rgbd_sensor/rgb/image_raw"/>
+        <arg name="filename" value="challenge_receptionist"/>
+    </include>
+
     <!-- Start the challenge -->
     <node pkg="challenge_receptionist" type="challenge_receptionist" name="state_machine" args="$(arg robot_name)" output="screen" required="true"/>
 

--- a/launch/state_machines/challenge_restaurant.launch
+++ b/launch/state_machines/challenge_restaurant.launch
@@ -26,6 +26,12 @@
 
     </group>
 
+    <!-- RECORD VIDEO -->
+    <include file="$(find robot_launch_files)/launch/tools/video_recorder.launch">
+        <arg name="image_topic" value="/hero/head_rgbd_sensor/rgb/image_raw"/>
+        <arg name="filename" value="challenge_restaurant"/>
+    </include>
+
     <!-- Don't start the challenge, first drive a little to initialze gmapping -->
 
 </launch>

--- a/launch/state_machines/challenge_rips.launch
+++ b/launch/state_machines/challenge_rips.launch
@@ -25,6 +25,12 @@
 
     </group>
 
+    <!-- RECORD VIDEO -->
+    <include file="$(find robot_launch_files)/launch/tools/video_recorder.launch">
+        <arg name="image_topic" value="/hero/head_rgbd_sensor/rgb/image_raw"/>
+        <arg name="filename" value="challenge_rips"/>
+    </include>
+
     <!-- Start the challenge -->
     <node pkg="challenge_rips" type="rips" name="state_machine" args="$(arg robot_name)" output="screen" required="true"/>
 

--- a/launch/state_machines/challenge_serve_breakfast.launch
+++ b/launch/state_machines/challenge_serve_breakfast.launch
@@ -23,6 +23,12 @@
         </include>
     </group>
 
+    <!-- RECORD VIDEO -->
+    <include file="$(find robot_launch_files)/launch/tools/video_recorder.launch">
+        <arg name="image_topic" value="/hero/head_rgbd_sensor/rgb/image_raw"/>
+        <arg name="filename" value="challenge_serve_breakfast"/>
+    </include>
+
     <!-- Start the challenge -->
     <node pkg="challenge_serve_breakfast" type="challenge_serve_breakfast" name="state_machine" args="hero" output="screen" required="true" />
 

--- a/launch/state_machines/challenge_storing_groceries.launch
+++ b/launch/state_machines/challenge_storing_groceries.launch
@@ -24,6 +24,12 @@
 
     </group>
 
+    <!-- RECORD VIDEO -->
+    <include file="$(find robot_launch_files)/launch/tools/video_recorder.launch">
+        <arg name="image_topic" value="/hero/head_rgbd_sensor/rgb/image_raw"/>
+        <arg name="filename" value="challenge_storing_groceries"/>
+    </include>
+
     <!-- Start the challenge -->
     <node pkg="challenge_storing_groceries" type="challenge_storing_groceries" name="state_machine" args="$(arg robot_name)" output="screen" required="true" />
 


### PR DESCRIPTION
the office asked us to record the video from the head camera during challenges. If we need to do this manually each time I think we will forget more often than not. So I propose to add the recorder to the challenge launch files.

Few things to consider are: How much video can we/do we want to store on Hero before deleting the oldest? Do we need to delete these manually?
Do we also want to record during testing? this means more (useless) video will be created but adding an if/unless statement to the launch file might mean we accidentally forget to record during a challenge. 